### PR TITLE
chore: idiomatic Rust refactoring and cleanups

### DIFF
--- a/src/metadata/metadata_extractor.rs
+++ b/src/metadata/metadata_extractor.rs
@@ -26,12 +26,12 @@ impl MetadataExtractor {
         let title = String::from(tag.title().unwrap_or(""));
         let artist = String::from(tag.artist().unwrap_or(""));
         let album_title = String::from(tag.album_title().unwrap_or(""));
-        if title == "" && artist == "" {
+        if title.is_empty() && artist.is_empty() {
             warn!("Artist or title is empty. Skipping song.");
             return None;
         }
         let duration = Self::get_duration(borrowed_song2).map_or(None, |seconds| Some(seconds));
-        return Some(SongMetadata { song: song.to_owned(), artist, title, album_title, duration });
+        Some(SongMetadata { song: song.to_owned(), artist, title, album_title, duration })
     }
     fn get_duration(song: Song) -> Result<u16, Error> {
         let file = File::open(song.filepath)?;

--- a/src/model/data_model.rs
+++ b/src/model/data_model.rs
@@ -106,13 +106,13 @@ impl AudioExtensions {
         String::from(os_string.to_str().unwrap_or(""))
     }
     pub fn get_extension_by_filepath(filepath: &Path) -> AudioExtensions {
-        let extensions = vec![MP3, OGG, M4A, FLAC, WAV, AIFF, WMA, AAC];
+        let extensions = [MP3, OGG, M4A, FLAC, WAV, AIFF, WMA, AAC];
         let current_extension = Self::get_extension_as_str(filepath);
         let result = extensions
             .into_iter()
             .find(|an_extension| current_extension.as_str() == an_extension.get_extension());
 
-        result.unwrap_or_else(|| UNKNOWN)
+        result.unwrap_or(UNKNOWN)
     }
 }
 impl Display for AudioExtensions {

--- a/src/writer/writer.rs
+++ b/src/writer/writer.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
-use log::{warn};
+use log::{error, warn};
 use crate::model::data_model::{Lyric, Writer};
 
 impl Writer {
@@ -20,7 +20,7 @@ impl Writer {
 
         // Write lyrics to the new file
         if let Err(e) = fs::write(&full_path, lyrics) {
-            eprintln!("Failed to write lyric file: {}", e);
+            error!("Failed to write lyric file: {}", e);
             return None;
         }
         Some(full_path)


### PR DESCRIPTION
This pull request focuses on code quality improvements and minor logic adjustments, primarily aiming to make the codebase more idiomatic and robust. The changes include replacing deprecated or less-preferred idioms, improving error logging, and making minor optimizations.

Code quality and idiomatic improvements:

* Replaced manual string emptiness checks with the more idiomatic `.is_empty()` method and removed an unnecessary explicit `return` in `MetadataExtractor`, improving code clarity and conciseness.
* Changed the construction of the `extensions` collection from a `Vec` to a fixed-size array in `AudioExtensions`, and replaced `unwrap_or_else` with `unwrap_or` for more idiomatic error handling.

Logging improvements:

* Updated the error logging in `Writer` to use the `log::error!` macro instead of `eprintln!`, ensuring consistent and configurable logging throughout the application. [[1]](diffhunk://#diff-e0d4f85badd74e68bdbecc6043fbca9e53bcf85498d98e861fc1f11f61aed0f2L3-R3) [[2]](diffhunk://#diff-e0d4f85badd74e68bdbecc6043fbca9e53bcf85498d98e861fc1f11f61aed0f2L23-R23)